### PR TITLE
The interface for adding built-in resource packs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,3 +84,7 @@ publishing {
         // retrieving dependencies.
     }
 }
+
+loom {
+    accessWidenerPath = file("src/main/resources/elegantia.accesswidener")
+}

--- a/src/main/java/io/github/aratakileo/elegantia/mixin/BuiltinPackSourceMixin.java
+++ b/src/main/java/io/github/aratakileo/elegantia/mixin/BuiltinPackSourceMixin.java
@@ -1,0 +1,25 @@
+package io.github.aratakileo.elegantia.mixin;
+
+import io.github.aratakileo.elegantia.util.ResourcePacksProvider;
+import net.minecraft.client.resources.ClientPackSource;
+import net.minecraft.server.packs.PackType;
+import net.minecraft.server.packs.repository.BuiltInPackSource;
+import net.minecraft.server.packs.repository.Pack;
+import net.minecraft.server.packs.repository.ServerPacksSource;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.function.Consumer;
+
+@Mixin(BuiltInPackSource.class)
+public class BuiltinPackSourceMixin {
+    @Inject(method = "listBundledPacks", at = @At("RETURN"))
+    private void listBundledPacks(Consumer<Pack> consumer, CallbackInfo ci) {
+        if (((Object)this) instanceof ServerPacksSource)
+            ResourcePacksProvider.consumeBuiltinPacks(PackType.CLIENT_RESOURCES, consumer);
+        else if (((Object)this) instanceof ClientPackSource)
+            ResourcePacksProvider.consumeBuiltinPacks(PackType.CLIENT_RESOURCES, consumer);
+    }
+}

--- a/src/main/java/io/github/aratakileo/elegantia/mixin/OptionsMixin.java
+++ b/src/main/java/io/github/aratakileo/elegantia/mixin/OptionsMixin.java
@@ -1,0 +1,60 @@
+package io.github.aratakileo.elegantia.mixin;
+
+import com.google.gson.Gson;
+import io.github.aratakileo.elegantia.ElegantiaConfig;
+import io.github.aratakileo.elegantia.util.ResourcePacksProvider;
+import net.minecraft.client.Options;
+import net.minecraft.server.packs.repository.PackRepository;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.gen.Accessor;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+@Mixin(Options.class)
+public class OptionsMixin {
+    @Shadow
+    public List<String> resourcePacks;
+
+    @Shadow
+    private static List<String> readPackList(String content) {
+        throw new IllegalStateException("Injection failed.");
+    }
+
+    @Shadow
+    @Final
+    static Gson GSON;
+
+    @Unique
+    private List<String> elegantia$defaultEnabledResourcePacks = new ArrayList<>();
+
+    @Inject(method = "processOptions", at = @At("HEAD"))
+    private void processOption(Options.FieldAccess fieldAccess, CallbackInfo ci) {
+        elegantia$defaultEnabledResourcePacks = fieldAccess.process(
+                "elegantia$defaultEnabledResourcePacks",
+                elegantia$defaultEnabledResourcePacks,
+                OptionsMixin::readPackList,
+                GSON::toJson
+        );
+    }
+
+    @Inject(method = "loadSelectedResourcePacks", at = @At("HEAD"))
+    private void loadSelectedResourcePacks(PackRepository repository, CallbackInfo ci) {
+
+        elegantia$defaultEnabledResourcePacks.removeIf(name -> Objects.isNull(repository.getPack(name)));
+
+        for (final var name: ResourcePacksProvider.getDefaultEnabledResourcePackNames()) {
+            if (elegantia$defaultEnabledResourcePacks.contains(name)) continue;
+
+            resourcePacks.add(name);
+            elegantia$defaultEnabledResourcePacks.add(name);
+        }
+    }
+}

--- a/src/main/java/io/github/aratakileo/elegantia/util/Platform.java
+++ b/src/main/java/io/github/aratakileo/elegantia/util/Platform.java
@@ -1,5 +1,7 @@
 package io.github.aratakileo.elegantia.util;
 
+import net.fabricmc.api.EnvType;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.SharedConstants;
 import org.jetbrains.annotations.NotNull;
 
@@ -19,5 +21,23 @@ public enum Platform {
 
     public static @NotNull String getMinecraftVersion() {
         return SharedConstants.getCurrentVersion().getName();
+    }
+
+    public static @NotNull Environment getEnvironment() {
+        return FabricLoader.getInstance().getEnvironmentType() == EnvType.CLIENT
+                ? Environment.CLIENT : Environment.SERVER;
+    }
+
+    public enum Environment {
+        CLIENT,
+        SERVER;
+
+        public boolean isClient() {
+            return this == CLIENT;
+        }
+
+        public boolean isServer() {
+            return  this == SERVER;
+        }
     }
 }

--- a/src/main/java/io/github/aratakileo/elegantia/util/ResourcePacksProvider.java
+++ b/src/main/java/io/github/aratakileo/elegantia/util/ResourcePacksProvider.java
@@ -1,0 +1,180 @@
+package io.github.aratakileo.elegantia.util;
+
+import net.minecraft.SharedConstants;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.PackType;
+import net.minecraft.server.packs.PathPackResources;
+import net.minecraft.server.packs.repository.Pack;
+import net.minecraft.server.packs.repository.PackSource;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+public final class ResourcePacksProvider {
+    private final static HashMap<String, Pack> CLIENT_RESOURCE_PACKS = new HashMap<>();
+    private final static HashMap<String, Pack> SERVER_RESOURCE_PACKS = new HashMap<>();
+    private final static ArrayList<String> DEFAULT_ENABLED_RESOURCE_PACK_NAMES = new ArrayList<>();
+
+    private final ResourceLocation packLocation;
+    private boolean autoCompatibilityCompliance = false, isDefaultEnabled = true;
+    private @NotNull String packsDirPath = "resourcepacks";
+    private @Nullable Component displayName = null;
+
+    private ResourcePacksProvider(@NotNull ResourceLocation packLocation) {
+        ModInfo.throwIfModIsNotLoaded(packLocation.getNamespace());
+
+        this.packLocation = packLocation;
+    }
+
+    public static @NotNull ResourcePacksProvider defineBuiltin(@NotNull ResourceLocation resourceLocation) {
+        return new ResourcePacksProvider(resourceLocation);
+    }
+
+    public static @NotNull ResourcePacksProvider defineBuiltin(
+            @NotNull String modId,
+            @NotNull String packDirPath
+    ) {
+        return new ResourcePacksProvider(new ResourceLocation(modId, packDirPath));
+    }
+
+    public @NotNull ResourcePacksProvider setAutoCompatibilityCompliance(boolean autoCompatibilityCompliance) {
+        this.autoCompatibilityCompliance = autoCompatibilityCompliance;
+        return this;
+    }
+
+    public @NotNull ResourcePacksProvider setDefaultEnabled(boolean defaultEnabled) {
+        isDefaultEnabled = defaultEnabled;
+        return this;
+    }
+
+    public @NotNull ResourcePacksProvider setPacksDirPath(@NotNull String packsDirPath) {
+        this.packsDirPath = packsDirPath;
+        return this;
+    }
+
+    public @NotNull ResourcePacksProvider setDisplayName(@NotNull Component displayName) {
+        this.displayName = displayName;
+        return this;
+    }
+
+    @SuppressWarnings("UnusedReturnValue")
+    public boolean register() {
+        final var optionalResourcePacksPath = ModInfo.findPath(
+                packLocation.getNamespace(),
+                packsDirPath
+        );
+
+        if (optionalResourcePacksPath.isEmpty()) return false;
+
+        final var resourcePackPath = optionalResourcePacksPath.get()
+                .resolve(packLocation.getPath())
+                .toAbsolutePath()
+                .normalize();
+
+        if (!Files.exists(resourcePackPath)) return false;
+
+        final var name = packLocation.toString();
+        final var finishedDisplayName = Objects.nonNull(displayName) ? displayName : Component.translatable(
+                "%s.resourcepack.%s.title".formatted(
+                        packLocation.getNamespace(),
+                        packLocation.getPath().replaceAll("[/\\\\]+", ".")
+                )
+        );
+
+        var result = Platform.getEnvironment().isClient() && registerBuiltin(
+                PackType.CLIENT_RESOURCES,
+                name,
+                finishedDisplayName,
+                resourcePackPath,
+                autoCompatibilityCompliance
+        );
+
+        result |= registerBuiltin(
+                PackType.SERVER_DATA,
+                name,
+                finishedDisplayName,
+                resourcePackPath,
+                autoCompatibilityCompliance
+        );
+
+        if (result && isDefaultEnabled)
+            DEFAULT_ENABLED_RESOURCE_PACK_NAMES.add(name);
+
+        return result;
+    }
+
+    public static void consumeBuiltinPacks(@NotNull PackType type, Consumer<Pack> packConsumer) {
+        final var builtinPacks = type == PackType.CLIENT_RESOURCES ? CLIENT_RESOURCE_PACKS : SERVER_RESOURCE_PACKS;
+
+        builtinPacks.values().forEach(packConsumer);
+    }
+
+    public static @NotNull List<String> getDefaultEnabledResourcePackNames() {
+        return DEFAULT_ENABLED_RESOURCE_PACK_NAMES;
+    }
+
+    private static boolean registerBuiltin(
+            @NotNull PackType packType,
+            @NotNull String name,
+            @NotNull Component displayName,
+            @NotNull Path resourcePackPath,
+            boolean autoCompatibilityCompliance
+    ) {
+        final var pack = createBuiltinPack(
+                packType,
+                name,
+                path -> new PathPackResources(path, resourcePackPath, false),
+                displayName,
+                autoCompatibilityCompliance
+        );
+
+        if (Objects.isNull(pack)) return false;
+
+        if (packType == PackType.CLIENT_RESOURCES)
+            CLIENT_RESOURCE_PACKS.put(pack.getId(), pack);
+        else
+            SERVER_RESOURCE_PACKS.put(pack.getId(), pack);
+
+        return true;
+    }
+
+    private static @Nullable Pack createBuiltinPack(
+            @NotNull PackType packType,
+            @NotNull String name,
+            @NotNull Pack.ResourcesSupplier resourcesSupplier,
+            @NotNull Component displayName,
+            boolean autoCompatibilityCompliance
+    ) {
+        var info = Pack.readPackInfo(name, resourcesSupplier);
+
+        if (Objects.isNull(info))
+            return null;
+
+        if (autoCompatibilityCompliance)
+            info = new Pack.Info(
+                    info.description(),
+                    SharedConstants.getCurrentVersion().getPackVersion(packType),
+                    info.requestedFeatures()
+            );
+
+        return Pack.create(
+                name,
+                displayName,
+                false,
+                resourcesSupplier,
+                info,
+                packType,
+                Pack.Position.TOP,
+                false,
+                PackSource.BUILT_IN
+        );
+    }
+}

--- a/src/main/resources/elegantia.accesswidener
+++ b/src/main/resources/elegantia.accesswidener
@@ -1,0 +1,3 @@
+accessWidener v1 named
+
+accessible class net/minecraft/client/Options$FieldAccess

--- a/src/main/resources/elegantia.mixins.json
+++ b/src/main/resources/elegantia.mixins.json
@@ -4,10 +4,12 @@
   "package": "io.github.aratakileo.elegantia.mixin",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
+    "BuiltinPackSourceMixin",
     "ReloadableResourceManagerMixin"
   ],
   "client": [
-    "GuiMixin"
+    "GuiMixin",
+    "OptionsMixin"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -27,5 +27,6 @@
   },
   "mixins": [
     "elegantia.mixins.json"
-  ]
+  ],
+  "accessWidener": "elegantia.accesswidener"
 }


### PR DESCRIPTION
It is an analog to Fabric's:
```java
ResourceManagerHelper.registerBuiltinResourcePack(...);
```
and to Quilt's:
```java
ResourceLoader.registerBuiltinResourcePack(...);
```
In the first case, the code depends on the Fabric API, in the second on the Quilt API. This implementation is independent of either. This implementation can also be easily scaled to Forge and Neogorge